### PR TITLE
fix(webpack-hook): replace webpack hook beforeRun to beforeCompile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export default class WebpackRemoteTypesPlugin {
   }
 
   apply(compiler: Compiler) {
-    compiler.hooks.beforeRun.tapPromise('WebpackRemoteTypesPlugin', () => {
+    compiler.hooks.beforeCompile.tapPromise('WebpackRemoteTypesPlugin', () => {
       return downloadFederationTypes(
         this.options.remotes,
         path.resolve(cwd, this.options.outputDir),


### PR DESCRIPTION
Not sure why, but `beforeRun` hook is not working on my setup, I'm using `webpack 5.37.1`, `webpack-cli 4.7.0`,  `webpack-dev-server 3.11.2`.
So I changed to `beforeCompile` and everything is working now.
