### PR TITLE
fix: avoid double downloads by changing used hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export default class WebpackRemoteTypesPlugin {
   }
 
   apply(compiler: Compiler) {
-    compiler.hooks.beforeCompile.tapPromise('WebpackRemoteTypesPlugin', () => {
+    compiler.hooks.afterPlugins.tap('WebpackRemoteTypesPlugin', () => {
       return downloadFederationTypes(
         this.options.remotes,
         path.resolve(cwd, this.options.outputDir),


### PR DESCRIPTION
use of `beforeCompile` hook caused double download, replaced with `afterPlugins`.