### PR TITLE
feat: support [name] placeholder in outputDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn add webpack-remote-types-plugin
     remotes: {
       app: 'app@http://localhost:9000/remoteEntry.js',
     },
-    outputDir: 'types',
+    outputDir: 'types', // supports [name] as the remote name
     remoteFileName: '[name]-dts.tgz' // default filename is [name]-dts.tgz where [name] is the remote name, for example, `app` with the above setup
   }),
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,11 +36,12 @@ async function downloadFederationTypes(
 
   for (const [, value] of Object.entries(remotes)) {
     const [moduleName, entryFileURL] = value.split('@')
+    const outputPath = outputDir.replace('[name]', moduleName)
     const dtsFileName = remoteFileName.replace('[name]', moduleName)
     const dtsFileURL = new URL(dtsFileName, entryFileURL).href
-    const targetFile = path.resolve(outputDir, dtsFileName)
+    const targetFile = path.resolve(outputPath, dtsFileName)
 
-    await fs.ensureDir(outputDir)
+    await fs.ensureDir(outputPath)
 
     console.log('Downloading: ', dtsFileURL)
     const saved = await downloadFile(dtsFileURL, targetFile)
@@ -49,7 +50,7 @@ async function downloadFederationTypes(
       console.log('Saved: ', targetFile)
       tar.x({
         file: targetFile,
-        cwd: outputDir,
+        cwd: outputPath,
       })
     } else {
       console.error('Failed to download remote DTS: ', dtsFileURL)


### PR DESCRIPTION
added `[name]` template to `outputDir` also. now it's more elastic with multiple remotes.